### PR TITLE
Add CryptoRoute to non-custodial swap tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -985,6 +985,7 @@ Don’t use Tornado and forget about it, but you can use:
 - [SideShift](https://sideshift.ai) or [AgoraDesk](https://agoradesk.com)
 - [How to fund an undoxxed Ethereum wallet off-chain](https://mirror.xyz/xanny.eth/SGxwfVQ75831z5vFaS1LrlatUJEhxBvZ2cyTvAdCD0k)
 - [changenow.io](https://changenow.io)
+- [CryptoRoute](https://cryptoroute.io) - non-custodial cross-chain swaps, no account or custody, you sign for your own funds
 - [tradeogre](https://tradeogre.com/markets)
 - ETH-XMR [atomic swap](https://github.com/noot/atomic-swap) - this one released via a bridge!
 - Maybe also check out: [Aztecnetwork](https://twitter.com/aztecnetwork) but always keep in mind [this dune dashboard!](https://dune.com/jaosef/Aztec-2)


### PR DESCRIPTION
Adds **CryptoRoute** to the non-custodial swap tools list (Problem 23), alongside SideShift and changenow.io.

- [CryptoRoute](https://cryptoroute.io) — non-custodial cross-chain swaps with no account and no custody; the user always signs for their own funds. Covers Bitcoin, Ethereum, Solana, TON, Tron and 20+ chains.

Relevant to the OpSec ethos of avoiding custodial exchanges. Single link, minimal diff.